### PR TITLE
Add prismjs to deps to prevent build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-plugin-react": "^6.2.0",
     "fixpack": "^2.3.1",
     "node-sass": "^3.8.0",
+    "prismjs": "^1.5.1",
     "react": "15.2.1",
     "react-dom": "15.2.1",
     "watchify": "^3.7.0"


### PR DESCRIPTION
When I run `npm run build:demo` on this repo

I got error like `Error: Cannot find module 'prismjs'`

So I add `prismjs` to dev dependencies.
